### PR TITLE
Refactor error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/webrtc-rs/sdp"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { package = "webrtc-rs-util", version = "0.1.0" }
 url = "2.1.0"
 rand = "0.8.0"
+thiserror = "1.0.23"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+use std::{num::ParseIntError, string::FromUtf8Error};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("codec not found")]
+    CodecNotFound,
+    #[error("could not extract codec from rtcp-fb")]
+    RtcpFb,
+    #[error("could not extract codec from fmtp")]
+    FmtpParse,
+    #[error("could not extract codec from rtpmap")]
+    RtpmapParse,
+    #[error("payload type not found")]
+    PayloadTypeNotFound,
+    #[error("SyntaxError: {0}")]
+    ExtMapParse(String),
+    #[error("sdp: empty time_descriptions")]
+    SdpEmptyTimeDescription,
+    #[error("SdpInvalidSyntax: {0}")]
+    SdpInvalidSyntax(String),
+    #[error("SdpInvalidValue: {0}")]
+    SdpInvalidValue(String),
+    #[error("FromUtf8Error: {0}")]
+    Utf8Error(#[from] FromUtf8Error),
+    #[error("ParseIntError: {0}")]
+    ParseIntError(#[from] ParseIntError),
+    #[error("UrlParseError: {0}")]
+    UrlParseError(#[from] url::ParseError),
+    #[error("IoError: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/src/extmap.rs
+++ b/src/extmap.rs
@@ -87,7 +87,10 @@ impl ExtMap {
         if valdir.len() == 2 {
             direction = Direction::new(valdir[1]);
             if direction == Direction::DirectionUnknown {
-                return Err(Error::ExtMapParse(format!("unknown direction from {}", valdir[1])));
+                return Err(Error::ExtMapParse(format!(
+                    "unknown direction from {}",
+                    valdir[1]
+                )));
             }
         }
 

--- a/src/extmap.rs
+++ b/src/extmap.rs
@@ -2,10 +2,10 @@ use std::fmt;
 use std::io;
 
 use url::Url;
-use util::Error;
 
 use super::common_description::*;
 use super::direction::*;
+use super::error::Error;
 
 #[cfg(test)]
 mod extmap_test;
@@ -66,19 +66,19 @@ impl ExtMap {
         reader.read_line(&mut line)?;
         let parts: Vec<&str> = line.trim().splitn(2, ':').collect();
         if parts.len() != 2 {
-            return Err(Error::new(format!("SyntaxError: {}", line)));
+            return Err(Error::ExtMapParse(line));
         }
 
         let fields: Vec<&str> = parts[1].split_whitespace().collect();
         if fields.len() < 2 {
-            return Err(Error::new(format!("SyntaxError: {}", line)));
+            return Err(Error::ExtMapParse(line));
         }
 
         let valdir: Vec<&str> = fields[0].split('/').collect();
         let value = valdir[0].parse::<isize>()?;
         if value < 1 || value > 246 {
-            return Err(Error::new(format!(
-                "SyntaxError: {} -- extmap key must be in the range 1-256",
+            return Err(Error::ExtMapParse(format!(
+                "{} -- extmap key must be in the range 1-256",
                 valdir[0]
             )));
         }
@@ -87,7 +87,7 @@ impl ExtMap {
         if valdir.len() == 2 {
             direction = Direction::new(valdir[1]);
             if direction == Direction::DirectionUnknown {
-                return Err(Error::new(format!("unknown direction from {}", valdir[1])));
+                return Err(Error::ExtMapParse(format!("unknown direction from {}", valdir[1])));
             }
         }
 

--- a/src/extmap/extmap_test.rs
+++ b/src/extmap/extmap_test.rs
@@ -1,8 +1,6 @@
 use super::*;
 use crate::util::{ATTRIBUTE_KEY, END_LINE};
 
-use util::Error;
-
 use std::io::BufReader;
 use std::iter::Iterator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 
 pub mod common_description;
 pub mod direction;
+pub mod error;
 pub mod extmap;
 pub mod media_description;
 pub mod session_description;
-pub mod error;
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod direction;
 pub mod extmap;
 pub mod media_description;
 pub mod session_description;
+pub mod error;
 pub mod util;

--- a/src/session_description.rs
+++ b/src/session_description.rs
@@ -5,8 +5,8 @@ use std::{fmt, io};
 use url::Url;
 
 use super::common_description::*;
-use super::media_description::*;
 use super::error::Error;
+use super::media_description::*;
 use super::util::*;
 
 #[cfg(test)]
@@ -1054,7 +1054,7 @@ fn unmarshal_bandwidth(value: &str) -> Result<Bandwidth, Error> {
         // https://tools.ietf.org/html/rfc4566#section-5.8
         let i = index_of(parts[0], &["CT", "AS"]);
         if i == -1 {
-        return Err(Error::SdpInvalidValue(parts[0].to_owned()));
+            return Err(Error::SdpInvalidValue(parts[0].to_owned()));
         }
     }
 

--- a/src/session_description.rs
+++ b/src/session_description.rs
@@ -3,10 +3,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::{fmt, io};
 
 use url::Url;
-use util::Error;
 
 use super::common_description::*;
 use super::media_description::*;
+use super::error::Error;
 use super::util::*;
 
 #[cfg(test)]
@@ -322,7 +322,7 @@ impl SessionDescription {
         if let Some(codec) = codecs.get(&payload_type) {
             Ok(codec.clone())
         } else {
-            Err(Error::new("payload type not found".to_string()))
+            Err(Error::PayloadTypeNotFound)
         }
     }
 
@@ -337,7 +337,7 @@ impl SessionDescription {
             }
         }
 
-        Err(Error::new("codec not found".to_string()))
+        Err(Error::CodecNotFound)
     }
     // Marshal takes a SDP struct to text
     // https://tools.ietf.org/html/rfc4566#section-5
@@ -542,7 +542,7 @@ fn s1<'a, R: io::BufRead + io::Seek>(
         }));
     }
 
-    Err(Error::new(format!("sdp: invalid syntax `{}`", key)))
+    Err(Error::SdpInvalidSyntax(key))
 }
 
 fn s2<'a, R: io::BufRead + io::Seek>(
@@ -555,7 +555,7 @@ fn s2<'a, R: io::BufRead + io::Seek>(
         }));
     }
 
-    Err(Error::new(format!("sdp: invalid syntax `{}`", key)))
+    Err(Error::SdpInvalidSyntax(key))
 }
 
 fn s3<'a, R: io::BufRead + io::Seek>(
@@ -568,7 +568,7 @@ fn s3<'a, R: io::BufRead + io::Seek>(
         }));
     }
 
-    Err(Error::new(format!("sdp: invalid syntax `{}`", key)))
+    Err(Error::SdpInvalidSyntax(key))
 }
 
 fn s4<'a, R: io::BufRead + io::Seek>(
@@ -591,7 +591,7 @@ fn s4<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -606,7 +606,7 @@ fn s5<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -625,7 +625,7 @@ fn s6<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -646,7 +646,7 @@ fn s7<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -664,7 +664,7 @@ fn s8<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -695,7 +695,7 @@ fn s9<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -715,7 +715,7 @@ fn s10<'a, R: io::BufRead + io::Seek>(
         "t=" => Ok(Some(StateFn {
             f: unmarshal_timing,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -734,7 +734,7 @@ fn s11<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -765,7 +765,7 @@ fn s12<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -787,7 +787,7 @@ fn s13<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -822,7 +822,7 @@ fn s14<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -854,7 +854,7 @@ fn s15<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -886,7 +886,7 @@ fn s16<'a, R: io::BufRead + io::Seek>(
         "m=" => Ok(Some(StateFn {
             f: unmarshal_media_description,
         })),
-        _ => Err(Error::new(format!("sdp: invalid syntax `{}`", key))),
+        _ => Err(Error::SdpInvalidSyntax(key)),
     }
 }
 
@@ -900,7 +900,7 @@ fn unmarshal_protocol_version<'a, R: io::BufRead + io::Seek>(
     // As off the latest draft of the rfc this value is required to be 0.
     // https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-24#section-5.8.1
     if version != 0 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", value)));
+        return Err(Error::SdpInvalidSyntax(value));
     }
 
     Ok(Some(StateFn { f: s2 }))
@@ -913,7 +913,7 @@ fn unmarshal_origin<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() != 6 {
-        return Err(Error::new(format!("sdp: invalid syntax `o={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`o={}`", value)));
     }
 
     let session_id = fields[1].parse::<u64>()?;
@@ -923,14 +923,14 @@ fn unmarshal_origin<'a, R: io::BufRead + io::Seek>(
     // https://tools.ietf.org/html/rfc4566#section-8.2.6
     let i = index_of(fields[3], &["IN"]);
     if i == -1 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", fields[3])));
+        return Err(Error::SdpInvalidValue(fields[3].to_owned()));
     }
 
     // Set according to currently registered with IANA
     // https://tools.ietf.org/html/rfc4566#section-8.2.7
     let i = index_of(fields[4], &["IP4", "IP6"]);
     if i == -1 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", fields[4])));
+        return Err(Error::SdpInvalidValue(fields[4].to_owned()));
     }
 
     // TODO validated UnicastAddress
@@ -998,21 +998,21 @@ fn unmarshal_session_connection_information<'a, R: io::BufRead + io::Seek>(
 fn unmarshal_connection_information(value: &str) -> Result<Option<ConnectionInformation>, Error> {
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 2 {
-        return Err(Error::new(format!("sdp: invalid syntax `c={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`c={}`", value)));
     }
 
     // Set according to currently registered with IANA
     // https://tools.ietf.org/html/rfc4566#section-8.2.6
     let i = index_of(fields[0], &["IN"]);
     if i == -1 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", fields[0])));
+        return Err(Error::SdpInvalidValue(fields[0].to_owned()));
     }
 
     // Set according to currently registered with IANA
     // https://tools.ietf.org/html/rfc4566#section-8.2.7
     let i = index_of(fields[1], &["IP4", "IP6"]);
     if i == -1 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", fields[1])));
+        return Err(Error::SdpInvalidValue(fields[1].to_owned()));
     }
 
     let address = if fields.len() > 2 {
@@ -1043,7 +1043,7 @@ fn unmarshal_session_bandwidth<'a, R: io::BufRead + io::Seek>(
 fn unmarshal_bandwidth(value: &str) -> Result<Bandwidth, Error> {
     let mut parts: Vec<&str> = value.split(':').collect();
     if parts.len() != 2 {
-        return Err(Error::new(format!("sdp: invalid syntax `b={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`b={}`", value)));
     }
 
     let experimental = parts[0].starts_with("X-");
@@ -1054,7 +1054,7 @@ fn unmarshal_bandwidth(value: &str) -> Result<Bandwidth, Error> {
         // https://tools.ietf.org/html/rfc4566#section-5.8
         let i = index_of(parts[0], &["CT", "AS"]);
         if i == -1 {
-            return Err(Error::new(format!("sdp: invalid value `{}`", parts[0])));
+        return Err(Error::SdpInvalidValue(parts[0].to_owned()));
         }
     }
 
@@ -1074,7 +1074,7 @@ fn unmarshal_timing<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 2 {
-        return Err(Error::new(format!("sdp: invalid syntax `t={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`t={}`", value)));
     }
 
     let start_time = fields[0].parse::<u64>()?;
@@ -1098,7 +1098,7 @@ fn unmarshal_repeat_times<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 3 {
-        return Err(Error::new(format!("sdp: invalid syntax `r={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`r={}`", value)));
     }
 
     if let Some(latest_time_desc) = lexer.desc.time_descriptions.last_mut() {
@@ -1117,7 +1117,7 @@ fn unmarshal_repeat_times<'a, R: io::BufRead + io::Seek>(
 
         Ok(Some(StateFn { f: s9 }))
     } else {
-        Err(Error::new("sdp: empty time_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 
@@ -1131,7 +1131,7 @@ fn unmarshal_time_zones<'a, R: io::BufRead + io::Seek>(
     // so we are making sure that there are actually multiple of 2 total.
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() % 2 != 0 {
-        return Err(Error::new(format!("sdp: invalid syntax `t={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`t={}`", value)));
     }
 
     for i in (0..fields.len()).step_by(2) {
@@ -1184,7 +1184,7 @@ fn unmarshal_media_description<'a, R: io::BufRead + io::Seek>(
 
     let fields: Vec<&str> = value.split_whitespace().collect();
     if fields.len() < 4 {
-        return Err(Error::new(format!("sdp: invalid syntax `m={}`", value)));
+        return Err(Error::SdpInvalidSyntax(format!("`m={}`", value)));
     }
 
     // <media>
@@ -1195,7 +1195,7 @@ fn unmarshal_media_description<'a, R: io::BufRead + io::Seek>(
         &["audio", "video", "text", "application", "message"],
     );
     if i == -1 {
-        return Err(Error::new(format!("sdp: invalid value `{}`", fields[0])));
+        return Err(Error::SdpInvalidValue(fields[0].to_owned()));
     }
 
     // <port>
@@ -1219,7 +1219,7 @@ fn unmarshal_media_description<'a, R: io::BufRead + io::Seek>(
             ],
         );
         if i == -1 {
-            return Err(Error::new(format!("sdp: invalid value `{}`", fields[2])));
+            return Err(Error::SdpInvalidValue(fields[2].to_owned()));
         }
         protos.push(proto.to_owned());
     }
@@ -1259,7 +1259,7 @@ fn unmarshal_media_title<'a, R: io::BufRead + io::Seek>(
         latest_media_desc.media_title = Some(value);
         Ok(Some(StateFn { f: s16 }))
     } else {
-        Err(Error::new("sdp: empty media_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 
@@ -1272,7 +1272,7 @@ fn unmarshal_media_connection_information<'a, R: io::BufRead + io::Seek>(
         latest_media_desc.connection_information = unmarshal_connection_information(&value)?;
         Ok(Some(StateFn { f: s15 }))
     } else {
-        Err(Error::new("sdp: empty media_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 
@@ -1286,7 +1286,7 @@ fn unmarshal_media_bandwidth<'a, R: io::BufRead + io::Seek>(
         latest_media_desc.bandwidth.push(bandwidth);
         Ok(Some(StateFn { f: s15 }))
     } else {
-        Err(Error::new("sdp: empty media_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 
@@ -1299,7 +1299,7 @@ fn unmarshal_media_encryption_key<'a, R: io::BufRead + io::Seek>(
         latest_media_desc.encryption_key = Some(value);
         Ok(Some(StateFn { f: s14 }))
     } else {
-        Err(Error::new("sdp: empty media_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 
@@ -1325,7 +1325,7 @@ fn unmarshal_media_attribute<'a, R: io::BufRead + io::Seek>(
         latest_media_desc.attributes.push(attribute);
         Ok(Some(StateFn { f: s14 }))
     } else {
-        Err(Error::new("sdp: empty media_descriptions".to_string()))
+        Err(Error::SdpEmptyTimeDescription)
     }
 }
 

--- a/src/session_description/session_description_test.rs
+++ b/src/session_description/session_description_test.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-use util::Error;
-
 use std::io::Cursor;
 
 const CANONICAL_MARSHAL_SDP: &'static str = "v=0\r\n\

--- a/src/util/util_test.rs
+++ b/src/util/util_test.rs
@@ -3,8 +3,6 @@ use crate::common_description::*;
 use crate::media_description::*;
 use crate::session_description::*;
 
-use util::Error;
-
 fn get_test_session_description() -> SessionDescription {
     return SessionDescription{
         media_descriptions: vec![


### PR DESCRIPTION
* Remove dependency on webrtc-rs-util as it's only used for error handling
* Add dependency on thiserror

I've refactored error handling to be a crate-specific Error enum, so the error cases for this crate are explicit. 😄 I've tried to make minimal changes to the project, keeping the error messages similar. I've used dtolnay's thiserror crate to simplify the implementation, it gets compiled away so it doesn't become a part of the API of the crate or a dependency of downstream crates like failure or anyhow would.