### PR TITLE
Fix Media attribute lookup

### DIFF
--- a/src/description/media.rs
+++ b/src/description/media.rs
@@ -60,10 +60,10 @@ pub struct MediaDescription {
 
 impl MediaDescription {
     /// attribute returns the value of an attribute and if it exists
-    pub fn attribute(&self, key: &str) -> Option<&String> {
+    pub fn attribute(&self, key: &str) -> Option<Option<&str>> {
         for a in &self.attributes {
             if a.key == key {
-                return a.value.as_ref();
+                return Some(a.value.as_ref().map(|s| s.as_ref()));
             }
         }
         None
@@ -237,5 +237,33 @@ impl fmt::Display for MediaName {
             self.formats.join(" "),
         ];
         write!(f, "{}", s.join(" "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MediaDescription;
+
+    #[test]
+    fn test_attribute_missing() {
+        let media_description = MediaDescription::default();
+
+        assert_eq!(media_description.attribute("recvonly"), None);
+    }
+
+    #[test]
+    fn test_attribute_present_with_no_value() {
+        let media_description =
+            MediaDescription::default().with_property_attribute("recvonly".to_owned());
+
+        assert_eq!(media_description.attribute("recvonly"), Some(None));
+    }
+
+    #[test]
+    fn test_attribute_present_with_value() {
+        let media_description =
+            MediaDescription::default().with_value_attribute("ptime".to_owned(), "1".to_owned());
+
+        assert_eq!(media_description.attribute("ptime"), Some(Some("1")));
     }
 }


### PR DESCRIPTION
The previous version of this API did not allow distinguishing between an attribute being present but having no value, such as `a=recvonly`, and the attribute being entirely missing.

With this change `attribute` will return:

* `None` when the attribute is missing.
* `Some(None)` when the attribute is present but has no value, such as `a=recvonly`.
* `Some(Some(&str))` when the attribute is present and has a value.
