### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -10,32 +10,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build and test
+  check_and_test:
+    name: Check and test
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        toolchain:
+          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - stable
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
-
-  rustfmt_and_clippy:
-    name: Check rustfmt style && run clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  rustfmt_and_clippy:
+    name: Check rustfmt style and run clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -43,8 +58,28 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- -D warnings
       - name: Check formating
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -69,7 +69,10 @@ jobs:
     name: Compile and test with minimal versions
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        # TODO: add 'windows-latest' once criterion#atty version is upgraded
+        # "0.2" min version (0.2.0) depends on winapi-0.2.4 which does not
+        # compile on nightly.
+        os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -72,6 +72,7 @@ jobs:
         # TODO: add 'windows-latest' once criterion#atty version is upgraded
         # "0.2" min version (0.2.0) depends on winapi-0.2.4 which does not
         # compile on nightly.
+        # https://github.com/bheisler/criterion.rs/pull/587
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://webrtc.rs"
 repository = "https://github.com/webrtc-rs/sdp"
 
 [dependencies]
-url = "2.2.2"
-rand = "0.8.4"
-thiserror = "1.0.30"
-substring = "1.4.5"
+url = "2.2"
+rand = "0.8.5"
+thiserror = "~1.0.10"
+substring = "1.4"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ substring = "1.4"
 [dev-dependencies]
 criterion = "0.3.5"
 
+# Prevents minimal-versions from failing on CI (windows)
+[target.'cfg(windows)'.dev-dependencies]
+winapi = "0.3"
+
 [[bench]]
 name = "bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ substring = "1.4"
 criterion = "0.3.5"
 
 # Prevents minimal-versions from failing on CI (windows)
-[target.'cfg(windows)'.dev-dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = "0.3"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ substring = "1.4"
 [dev-dependencies]
 criterion = "0.3.5"
 
-# Prevents minimal-versions from failing on CI (windows)
-[target.'cfg(windows)'.dependencies]
-winapi = "0.3"
-
 [[bench]]
 name = "bench"
 harness = false

--- a/src/direction/mod.rs
+++ b/src/direction/mod.rs
@@ -4,7 +4,7 @@ use std::fmt;
 mod direction_test;
 
 /// Direction is a marker for transmission direction of an endpoint
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Direction {
     Unspecified = 0,
     /// Direction::SendRecv is for bidirectional communication

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,7 +9,7 @@ use std::fmt;
 pub const ATTRIBUTE_KEY: &str = "a=";
 
 /// ConnectionRole indicates which of the end points should initiate the connection establishment
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ConnectionRole {
     Unspecified,
 
@@ -84,7 +84,7 @@ pub(crate) fn new_session_id() -> u64 {
 }
 
 // Codec represents a codec
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Codec {
     pub payload_type: u8,
     pub name: String,


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    OR specify major&minor versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions